### PR TITLE
Update SearchableModelMakeCommand.php

### DIFF
--- a/src/Console/SearchableModelMakeCommand.php
+++ b/src/Console/SearchableModelMakeCommand.php
@@ -41,7 +41,7 @@ class SearchableModelMakeCommand extends ModelMakeCommand
 
         $options[] = [
             'search-rule',
-            'sm'
+            'sm',
             null,
             InputOption::VALUE_REQUIRED,
             'Specify the search rule for the model. It\'ll be created if doesn\'t exist.',

--- a/src/Console/SearchableModelMakeCommand.php
+++ b/src/Console/SearchableModelMakeCommand.php
@@ -2,8 +2,8 @@
 
 namespace ScoutElastic\Console;
 
-use Illuminate\Foundation\Console\ModelMakeCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Illuminate\Foundation\Console\ModelMakeCommand;
 
 class SearchableModelMakeCommand extends ModelMakeCommand
 {
@@ -42,7 +42,6 @@ class SearchableModelMakeCommand extends ModelMakeCommand
         $options[] = [
             'search-rule',
             'sm',
-            null,
             InputOption::VALUE_REQUIRED,
             'Specify the search rule for the model. It\'ll be created if doesn\'t exist.',
         ];

--- a/src/Console/SearchableModelMakeCommand.php
+++ b/src/Console/SearchableModelMakeCommand.php
@@ -41,6 +41,7 @@ class SearchableModelMakeCommand extends ModelMakeCommand
 
         $options[] = [
             'search-rule',
+            'sm'
             null,
             InputOption::VALUE_REQUIRED,
             'Specify the search rule for the model. It\'ll be created if doesn\'t exist.',


### PR DESCRIPTION
Renames the --search-rule shortcut option -s to -sm, because -s is already taken bij --seed.